### PR TITLE
Add proxy support

### DIFF
--- a/Node/.vscode/tasks.json
+++ b/Node/.vscode/tasks.json
@@ -1,0 +1,10 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "0.1.0",
+    "command": "tsc",
+    "isShellCommand": true,
+    "args": ["-p", "."],
+    "showOutput": "silent",
+    "problemMatcher": "$tsc"
+}

--- a/Node/src/QnAMakerDialog.ts
+++ b/Node/src/QnAMakerDialog.ts
@@ -32,32 +32,29 @@
 //
 
 import * as builder from 'botbuilder';
-import { QnAMakerRecognizer, IQnAMakerResult, IQnAMakerOptions } from './QnAMakerRecognizer'; 
+import { QnAMakerRecognizer, IQnAMakerResult, IQnAMakerOptions } from './QnAMakerRecognizer';
 
 export class QnAMakerDialog extends builder.Dialog {
-	private answerThreshold: number;
-	private defaultNoMatchMessage: string;
+    private answerThreshold: number;
+    private defaultNoMatchMessage: string;
     private recognizers: builder.IntentRecognizerSet;
 
-    constructor(private options: IQnAMakerOptions){
+    constructor(private options: IQnAMakerOptions) {
         super();
         this.recognizers = new builder.IntentRecognizerSet(options);
-		if(typeof this.options.qnaThreshold !== 'number'){
-			this.answerThreshold = 0.3;
-		}
-		else
-		{
-			this.answerThreshold = this.options.qnaThreshold;
-		}
-		if(this.options.defaultMessage && this.options.defaultMessage !== "")
-		{
-			this.defaultNoMatchMessage = this.options.defaultMessage;
-		}
-		else
-		{
-			this.defaultNoMatchMessage = "No match found!";
-		}
-	}
+        if (typeof this.options.qnaThreshold !== 'number') {
+            this.answerThreshold = 0.3;
+        }
+        else {
+            this.answerThreshold = this.options.qnaThreshold;
+        }
+        if (this.options.defaultMessage && this.options.defaultMessage !== "") {
+            this.defaultNoMatchMessage = this.options.defaultMessage;
+        }
+        else {
+            this.defaultNoMatchMessage = "No match found!";
+        }
+    }
 
     public replyReceived(session: builder.Session, recognizeResult?: builder.IIntentRecognizerResult): void {
         var threshold = this.answerThreshold;
@@ -68,14 +65,14 @@ export class QnAMakerDialog extends builder.Dialog {
             context.dialogData = session.dialogData;
             context.activeDialog = true;
             this.recognize(context, (error, result) => {
-                    try {
-                        if(!error){
-                            this.invokeAnswer(session, result, threshold, noMatchMessage);
-                        }
-                    } catch (e) {
-                        this.emitError(session, e);
+                try {
+                    if (!error) {
+                        this.invokeAnswer(session, result, threshold, noMatchMessage);
                     }
+                } catch (e) {
+                    this.emitError(session, e);
                 }
+            }
             );
         } else {
             this.invokeAnswer(session, recognizeResult, threshold, noMatchMessage);
@@ -92,7 +89,7 @@ export class QnAMakerDialog extends builder.Dialog {
         return this;
 
     }
-	
+
     private invokeAnswer(session: builder.Session, recognizeResult: builder.IIntentRecognizerResult, threshold: number, noMatchMessage: string): void {
         var qnaMakerResult = recognizeResult as IQnAMakerResult;
         if (qnaMakerResult.score >= threshold) {
@@ -103,9 +100,9 @@ export class QnAMakerDialog extends builder.Dialog {
         }
     }
 
-	private emitError(session: builder.Session, err: Error): void {
-		var m = err.toString();
-		err = err instanceof Error ? err : new Error(m);
-		session.error(err);
-	}
+    private emitError(session: builder.Session, err: Error): void {
+        var m = err.toString();
+        err = err instanceof Error ? err : new Error(m);
+        session.error(err);
+    }
 }

--- a/Node/src/tsconfig.json
+++ b/Node/src/tsconfig.json
@@ -6,7 +6,8 @@
         "noImplicitAny": true,
         "outDir": "../built",
         "noEmitOnError": true,
-        "removeComments": true
+        "removeComments": true,
+        "watch": true
     },
     "exclude": [
         "botbuilder-cognitiveservices.d.ts"


### PR DESCRIPTION
Currently the BotBuilder-CognitiveServices doesn't support proxy for local testing and debugging.
Setting a global proxy at environment level may solve that issue but fails the communication between bot emulator.

My solution was to add proxy option in the QnAMakerRecognizer constructor. This gives the developer flexibility to set the proxy when they need to. Here is the sample code of how to use it:

```
var cognitiveservices = require("botbuilder-cognitiveservices");

var recognizer = new cognitiveservices.QnAMakerRecognizer({
    knowledgeBaseId: process.env.QnAKnowledgebaseId,
    subscriptionKey: process.env.QnASubscriptionKey,
    proxy: process.env.ProxyUrl
});
```