### PR TITLE
Check HTTP status code, to handle errors

### DIFF
--- a/Node/lib/QnAMakerRecognizer.js
+++ b/Node/lib/QnAMakerRecognizer.js
@@ -49,22 +49,27 @@ var QnAMakerRecognizer = (function () {
                 var result;
                 try {
                     if (!error) {
-                        result = JSON.parse(body);
-                        var answerEntities = [];
-                        if (result.answers !== null && result.answers.length > 0) {
-                            result.answers.forEach(function (ans) {
-                                ans.score /= 100;
-                                ans.answer = htmlentities.decode(ans.answer);
-                                var answerEntity = {
-                                    score: ans.score,
-                                    entity: ans.answer,
-                                    type: 'answer'
-                                };
-                                answerEntities.push(answerEntity);
-                            });
-                            result.score = result.answers[0].score;
-                            result.entities = answerEntities;
-                            result.intent = intentName;
+                        if (response.statusCode === 200) {
+                            result = JSON.parse(body);
+                            var answerEntities = [];
+                            if (result.answers && result.answers.length > 0) {
+                                result.answers.forEach(function (ans) {
+                                    ans.score /= 100;
+                                    ans.answer = htmlentities.decode(ans.answer);
+                                    var answerEntity = {
+                                        score: ans.score,
+                                        entity: ans.answer,
+                                        type: 'answer'
+                                    };
+                                    answerEntities.push(answerEntity);
+                                });
+                                result.score = result.answers[0].score;
+                                result.entities = answerEntities;
+                                result.intent = intentName;
+                            }
+                        }
+                        else {
+                            error = new Error(body);
                         }
                     }
                 }

--- a/Node/src/QnAMakerRecognizer.ts
+++ b/Node/src/QnAMakerRecognizer.ts
@@ -113,22 +113,26 @@ export class QnAMakerRecognizer implements builder.IIntentRecognizer {
                     var result: IQnAMakerResults;
                     try {
                         if (!error) {
-                            result = JSON.parse(body);
-                            var answerEntities: builder.IEntity[] = [];
-                            if(result.answers !== null && result.answers.length > 0){
-                                result.answers.forEach((ans) => {
-                                    ans.score /= 100;
-                                    ans.answer = htmlentities.decode(ans.answer);
-                                    var answerEntity = {
-                                        score: ans.score,
-                                        entity: ans.answer,
-                                        type: 'answer'
-                                    }
-                                    answerEntities.push(answerEntity as builder.IEntity);
-                                });
-                                result.score = result.answers[0].score;
-                                result.entities = answerEntities;
-                                result.intent = intentName;
+                            if (response.statusCode === 200) {
+                                result = JSON.parse(body);
+                                var answerEntities: builder.IEntity[] = [];
+                                if(result.answers && result.answers.length > 0){
+                                    result.answers.forEach((ans) => {
+                                        ans.score /= 100;
+                                        ans.answer = htmlentities.decode(ans.answer);
+                                        var answerEntity = {
+                                            score: ans.score,
+                                            entity: ans.answer,
+                                            type: 'answer'
+                                        }
+                                        answerEntities.push(answerEntity as builder.IEntity);
+                                    });
+                                    result.score = result.answers[0].score;
+                                    result.entities = answerEntities;
+                                    result.intent = intentName;
+                                }
+                            } else {
+                                error = new Error(body);
                             }
                         }
                     } catch (e) {


### PR DESCRIPTION
Check response HTTP status code before assuming it is correct, as errors might occur at this point (quota exceeded, service unavailable, etc.). With this change, these errors are visible from the clients.

`result.answers !== null` has been replaced with `result.answers`, as it was not checking correctly an empty property (should have been `result.answers !== undefined` or `result.answers != null`), and it is cleaner to check just for [truthy values](https://developer.mozilla.org/es/docs/Glossary/Truthy)

Related to https://github.com/Microsoft/BotBuilder/pull/3007