### PR TITLE
Stringify JSON automatically by request

### DIFF
--- a/Node/lib/QnAMakerRecognizer.js
+++ b/Node/lib/QnAMakerRecognizer.js
@@ -36,20 +36,20 @@ var QnAMakerRecognizer = (function () {
     };
     QnAMakerRecognizer.recognize = function (utterance, kbUrl, ocpApimSubscriptionKey, top, intentName, callback) {
         try {
-            var postBody = '{"question":"' + utterance + '", "top":' + top + '}';
             request({
                 url: kbUrl,
                 method: 'POST',
                 headers: {
-                    'Content-Type': 'application/json',
                     'Ocp-Apim-Subscription-Key': ocpApimSubscriptionKey
                 },
-                body: postBody
-            }, function (error, response, body) {
+                json: {
+                    question: utterance,
+                    top: top
+                }
+            }, function (error, response, result) {
                 var result;
                 try {
                     if (!error) {
-                        result = JSON.parse(body);
                         var answerEntities = [];
                         if (result.answers !== null && result.answers.length > 0) {
                             result.answers.forEach(function (ans) {

--- a/Node/src/QnAMakerRecognizer.ts
+++ b/Node/src/QnAMakerRecognizer.ts
@@ -99,21 +99,21 @@ export class QnAMakerRecognizer implements builder.IIntentRecognizer {
 
     static recognize(utterance: string, kbUrl: string, ocpApimSubscriptionKey: string, top: number, intentName: string, callback: (error: Error, result?: IQnAMakerResults) => void): void {
         try {
-            var postBody = '{"question":"' + utterance + '", "top":' + top + '}';
             request({
                 url: kbUrl,
                 method: 'POST',
                 headers: {
-                    'Content-Type': 'application/json',
                     'Ocp-Apim-Subscription-Key': ocpApimSubscriptionKey
                 },
-                body: postBody
+                json: {
+                    question: utterance,
+                    top: top
+                }
             },
-                function (error: Error, response: any, body: string) {
+                function (error: Error, response: any, result: IQnAMakerResults) {
                     var result: IQnAMakerResults;
                     try {
                         if (!error) {
-                            result = JSON.parse(body);
                             var answerEntities: builder.IEntity[] = [];
                             if(result.answers !== null && result.answers.length > 0){
                                 result.answers.forEach((ans) => {


### PR DESCRIPTION
Fixed bug when generating the JSON body. If utterance has quotes inside, the JSON is bad formed.

One solution is to create an object and `JSON.stringify` it in `postBody` var, or let request do it automatically (and parse the response automatically too), `content-type` header is not necessary in last case.