### PR TITLE
Issue 50: 

### DIFF
--- a/Node/lib/QnAMakerDialog.js
+++ b/Node/lib/QnAMakerDialog.js
@@ -80,9 +80,14 @@ var QnAMakerDialog = (function (_super) {
             }
         }
         else {
-            session.send(noMatchMessage);
-            this.defaultWaitNextMessage(session, qnaMakerResult);
+            this.noMatch(session, noMatchMessage, qnaMakerResult);
         }
+    };
+    QnAMakerDialog.prototype.noMatch(session, noMatchMessage, qnaMakerResult)
+    {
+        session.send(noMatchMessage);
+        this.defaultWaitNextMessage(session, qnaMakerResult);
+
     };
     QnAMakerDialog.prototype.qnaFeedbackStep = function (session, qnaMakerResult) {
         this.qnaMakerTools.answerSelector(session, qnaMakerResult);

--- a/Node/src/QnAMakerDialog.ts
+++ b/Node/src/QnAMakerDialog.ts
@@ -114,10 +114,14 @@ export class QnAMakerDialog extends builder.Dialog {
             }
         }
         else {
-            session.send(noMatchMessage);
-            this.defaultWaitNextMessage(session, qnaMakerResult);
+            this.noMatch(session, noMatchMessage, qnaMakerResult);
         }
-    }
+    };
+
+    public noMatch(session: builder.Session, noMatchMessage: string, qnaMakerResult: IQnAMakerResults) : void {
+        session.send(noMatchMessage);
+        this.defaultWaitNextMessage(session, qnaMakerResult);
+    };
 
     public qnaFeedbackStep(session: builder.Session, qnaMakerResult: IQnAMakerResults) : void {
         this.qnaMakerTools.answerSelector(session, qnaMakerResult);

--- a/Node/src/QnAMakerDialog.ts
+++ b/Node/src/QnAMakerDialog.ts
@@ -116,12 +116,12 @@ export class QnAMakerDialog extends builder.Dialog {
         else {
             this.noMatch(session, noMatchMessage, qnaMakerResult);
         }
-    };
+    }
 
     public noMatch(session: builder.Session, noMatchMessage: string, qnaMakerResult: IQnAMakerResults) : void {
         session.send(noMatchMessage);
         this.defaultWaitNextMessage(session, qnaMakerResult);
-    };
+    }
 
     public qnaFeedbackStep(session: builder.Session, qnaMakerResult: IQnAMakerResults) : void {
         this.qnaMakerTools.answerSelector(session, qnaMakerResult);


### PR DESCRIPTION
As per [Issue 50](https://github.com/Microsoft/BotBuilder-CognitiveServices/issues/50) this pull request is to provide an overridable method for changing the default behaviour when there is no match in the QnA database.