### PR TITLE
Fix for Issue 81 to override begin method

### DIFF
--- a/Node/src/QnAMakerDialog.ts
+++ b/Node/src/QnAMakerDialog.ts
@@ -68,6 +68,10 @@ export class QnAMakerDialog extends builder.Dialog {
         }
     }
 
+    public begin(session: builder.Session, recognizeResult?: builder.IIntentRecognizerResult): void {
+        this.replyReceived(session, recognizeResult);
+    }
+    
     public replyReceived(session: builder.Session, recognizeResult?: builder.IIntentRecognizerResult): void {
         var threshold = this.answerThreshold;
         var noMatchMessage = this.defaultNoMatchMessage;


### PR DESCRIPTION
For [Issue 81](https://github.com/Microsoft/BotBuilder-CognitiveServices/issues/81) this pull request provides a begin method to QnAMakerDialog so that it can handle recognizeResult as obtained previously rather than gathering the result all over again and thereby causing 2 calls to QnA for single request.