### PR TITLE
Possibility of override sendDefaultMessageAndWait

### DIFF
--- a/CSharp/Library/QnAMaker/QnAMaker/QnAMakerDialog.cs
+++ b/CSharp/Library/QnAMaker/QnAMaker/QnAMakerDialog.cs
@@ -118,8 +118,7 @@ namespace Microsoft.Bot.Builder.CognitiveServices.QnAMaker
 
                     if (sendDefaultMessageAndWait)
                     {
-                        await context.PostAsync(qnaMakerResults.ServiceCfg.DefaultMessage);
-                        await this.DefaultWaitNextMessageAsync(context, message, qnaMakerResults);
+                        await this.SendDefaultMessageAndWaitAsync(context, message, qnaMakerResults);
                     }
                 }
             }
@@ -198,6 +197,12 @@ namespace Microsoft.Bot.Builder.CognitiveServices.QnAMaker
         protected virtual async Task RespondFromQnAMakerResultAsync(IDialogContext context, IMessageActivity message, QnAMakerResults result)
         {
             await context.PostAsync(result.Answers.First().Answer);
+        }
+
+        protected virtual async Task SendDefaultMessageAndWaitAsync(IDialogContext context, IMessageActivity message, QnAMakerResults result)
+        {
+            await context.PostAsync(qnaMakerResults.ServiceCfg.DefaultMessage);
+            await this.DefaultWaitNextMessageAsync(context, message, qnaMakerResults);
         }
 
         protected virtual async Task DefaultWaitNextMessageAsync(IDialogContext context, IMessageActivity message, QnAMakerResults result)


### PR DESCRIPTION
Hello,

I would like wrap sendDefaultMessageAndWait actions into a virtual method that can be overriden.

Resolve the same problem than issue https://github.com/Microsoft/BotBuilder-CognitiveServices/issues/58