### PR TITLE
Allow custom default return messages

### DIFF
--- a/CSharp/Library/QnAMaker/QnAMaker/QnAMakerDialog.cs
+++ b/CSharp/Library/QnAMaker/QnAMaker/QnAMakerDialog.cs
@@ -118,11 +118,17 @@ namespace Microsoft.Bot.Builder.CognitiveServices.QnAMaker
 
                     if (sendDefaultMessageAndWait)
                     {
-                        await context.PostAsync(qnaMakerResults.ServiceCfg.DefaultMessage);
+                        var responseMessage = ((Activity)context.Activity).CreateReply(qnaMakerResults.ServiceCfg.DefaultMessage);
+                        UpdateDefaultMessageResponse(message.Text, responseMessage);
+                        await context.PostAsync(responseMessage);
                         await this.DefaultWaitNextMessageAsync(context, message, qnaMakerResults);
                     }
                 }
             }
+        }
+
+        protected virtual void UpdateDefaultMessageResponse(string originalQuery, IMessageActivity response)
+        {
         }
 
         protected virtual bool IsConfidentAnswer(QnAMakerResults qnaMakerResults)

--- a/CSharp/Library/QnAMaker/QnAMaker/QnAMakerDialog.cs
+++ b/CSharp/Library/QnAMaker/QnAMaker/QnAMakerDialog.cs
@@ -118,17 +118,11 @@ namespace Microsoft.Bot.Builder.CognitiveServices.QnAMaker
 
                     if (sendDefaultMessageAndWait)
                     {
-                        var responseMessage = ((Activity)context.Activity).CreateReply(qnaMakerResults.ServiceCfg.DefaultMessage);
-                        UpdateDefaultMessageResponse(message.Text, responseMessage);
-                        await context.PostAsync(responseMessage);
+                        await RespondWithDefaultMessageAsync(context, message);
                         await this.DefaultWaitNextMessageAsync(context, message, qnaMakerResults);
                     }
                 }
             }
-        }
-
-        protected virtual void UpdateDefaultMessageResponse(string originalQuery, IMessageActivity response)
-        {
         }
 
         protected virtual bool IsConfidentAnswer(QnAMakerResults qnaMakerResults)
@@ -209,6 +203,11 @@ namespace Microsoft.Bot.Builder.CognitiveServices.QnAMaker
         protected virtual async Task DefaultWaitNextMessageAsync(IDialogContext context, IMessageActivity message, QnAMakerResults result)
         {
             context.Done(true);
+        }
+
+        protected virtual async Task RespondWithDefaultMessageAsync(IDialogContext context, IMessageActivity request)
+        {
+            await context.PostAsync(qnaMakerResults.ServiceCfg.DefaultMessage);
         }
     }
 }

--- a/CSharp/Samples/QnAMaker/QnABotWithOverrides/Dialogs/QnADialogWithOverrides.cs
+++ b/CSharp/Samples/QnAMaker/QnABotWithOverrides/Dialogs/QnADialogWithOverrides.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Connector;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace QnABotWithOverrides.Dialogs
 {
@@ -27,6 +28,21 @@ namespace QnABotWithOverrides.Dialogs
             Console.WriteLine("KB Question: " + results.Answers.First().Questions.First());
             Console.WriteLine("KB Answer: " + results.Answers.First().Answer);
             await base.DefaultWaitNextMessageAsync(context, message, results);
+        }
+
+        // Override default message to offer assitance with a suggested action card
+        protected override async Task RespondWithDefaultMessageAsync(IDialogContext context, IMessageActivity request)
+        {
+            var activity = ((Activity)context.Activity).CreateReply("Sorry, I don't understand this right now. Try another query!");
+            activity.SuggestedActions = new SuggestedActions(actions:
+                                            new List<CardAction>
+                                            {
+                                                new CardAction() {
+                                                    Title = "Try asking Bing!",
+                                                    Value = $"https://bing.com/search?q={request.Text}",
+                                                    Type = ActionTypes.OpenUrl }
+                                            });
+            await context.PostAsync(activity);
         }
     }
 }


### PR DESCRIPTION
Allow customization of the response default response message.

The current default response message (when no QnA match is found) is just text. It would be useful to be able to allow providing prompts along with the default message to enable scenarios such as "provide a suggested action to contact an agent."

The suggested solution is to change the behavior from just sending a default text string to calling a virtual function so that it can be easily overridden. The default behavior of the function would be to just send the text string.

The virtual method should also have easy access to the original request activity (via a parameter) to incorporate the query into the custom response.

Below is a sample of how it could be used (which is also added to the QnABotWithOverrides sample)

```csharp
protected override async Task RespondWithDefaultMessageAsync(IDialogContext context, IMessageActivity request)
{
    var activity = ((Activity)context.Activity).CreateReply("Sorry, I don't understand");
    activity.SuggestedActions = new SuggestedActions(actions:
                                    new List<CardAction>
                                    {
                                        new CardAction() {
                                            Title = "Try asking Bing!",
                                            Value = $"https://bing.com/search?q={request.Text}",
                                            Type = ActionTypes.OpenUrl }
                                    });
    await context.PostAsync(activity);
}
```

This is similar to similar proposal in Node.js #76 