### PR TITLE
Fix InvalidCastException issue at action binding List Entity type

### DIFF
--- a/CSharp/Library/LuisActionBinding/LuisActionResolver.cs
+++ b/CSharp/Library/LuisActionBinding/LuisActionResolver.cs
@@ -1,15 +1,15 @@
-﻿// 
+﻿//
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license.
-// 
+//
 // Microsoft Bot Framework: http://botframework.com
-// 
+//
 // Cognitive Services based Dialogs for Bot Builder:
-// https://github.com/Microsoft/BotBuilder-CognitiveServices 
-// 
+// https://github.com/Microsoft/BotBuilder-CognitiveServices
+//
 // Copyright (c) Microsoft Corporation
 // All rights reserved.
-// 
+//
 // MIT License:
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the
@@ -18,10 +18,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED ""AS IS"", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -522,6 +522,10 @@ namespace Microsoft.Bot.Builder.CognitiveServices.LuisActionBinding
         {
             object result = value;
 
+            if (value is List<object>)
+            {
+                result = (string)((List<object>)value).FirstOrDefault(); ;
+            }
             // handle case where input is JArray returned from LUIS
             if (value is JArray)
             {


### PR DESCRIPTION
Fixed an InvalidCastException that caused the matching type of matchingEntity to be incorrect. more details
issue #89 