### PR TITLE
QnAMaker: include metadata and source in QnAMakerResult

### DIFF
--- a/CSharp/Library/QnAMaker/QnAMaker/QnAMakerService/QnAMakerResult.cs
+++ b/CSharp/Library/QnAMaker/QnAMaker/QnAMakerService/QnAMakerResult.cs
@@ -91,5 +91,21 @@ namespace Microsoft.Bot.Builder.CognitiveServices.QnAMaker
         /// </summary>
         [JsonProperty(PropertyName = "score")]
         public double Score { get; set; }
+        
+        /// <summary>
+        /// The list of metadata associated to the answer.
+        /// </summary>
+        [JsonProperty(PropertyName = "metadata")]
+        public List<QnAMakerMetadata> Metadata { get; set; }
+    }
+
+    [Serializable]
+    public class QnAMakerMetadata
+    {
+        [JsonProperty(PropertyName = "name")]
+        public string Name { get; set; }
+
+        [JsonProperty(PropertyName = "value")]
+        public string Value { get; set; }
     }
 }

--- a/CSharp/Library/QnAMaker/QnAMaker/QnAMakerService/QnAMakerResult.cs
+++ b/CSharp/Library/QnAMaker/QnAMaker/QnAMakerService/QnAMakerResult.cs
@@ -93,6 +93,12 @@ namespace Microsoft.Bot.Builder.CognitiveServices.QnAMaker
         public double Score { get; set; }
         
         /// <summary>
+        /// The source of the answer found in the QnA Service.
+        /// </summary>
+        [JsonProperty(PropertyName = "source")]
+        public string Source { get; set; }
+
+        /// <summary>
         /// The list of metadata associated to the answer.
         /// </summary>
         [JsonProperty(PropertyName = "metadata")]


### PR DESCRIPTION
QnAMaker can include metadata (AKA filters) that are returned with the answers. Currently, the Microsoft.Bot.Builder.CognitiveServices.QnAMaker library does not support it.
This PR adds the missing properties "metadata" and "source" from the answer response in the QnAMakerResult model (https://westus.dev.cognitive.microsoft.com/docs/services/597029932bcd590e74b648fb/operations/59703a928eb8131608e2f7a5).