### PR TITLE
Locale support

### DIFF
--- a/Node/lib/QnAMakerRecognizer.js
+++ b/Node/lib/QnAMakerRecognizer.js
@@ -12,22 +12,10 @@ var QnAMakerRecognizer = (function () {
     function QnAMakerRecognizer(options) {
         this.options = options;
         if (this.options.endpointHostName != null) {
-            var hostName = this.options.endpointHostName.toLowerCase();
-            if (hostName.indexOf('https://') > -1)
-                hostName = hostName.split('/')[2];
-            if (hostName.indexOf("qnamaker") > -1) {
-                hostName = hostName.split('/')[0];
-            }
-            hostName = hostName.replace("/", "");
-            this.kbUri = 'https://' + hostName + '/qnamaker/knowledgebases/' + this.options.knowledgeBaseId + '/' + qnaApi;
-            this.authHeader = 'Authorization';
-            var re = /endpointkey/gi;
-            if (this.options.authKey.search(re) > -1) {
-                this.authorizationKey = this.options.authKey.trim();
-            }
-            else {
-                this.authorizationKey = 'EndpointKey ' + this.options.authKey.trim();
-            }
+            var authInfo = QnAMakerRecognizer.getAuthValues(options.endpointHostName, options.authKey, options.knowledgeBaseId);
+            this.kbUri = authInfo.kbUri;
+            this.authHeader = authInfo.authHeader;
+            this.authorizationKey = authInfo.authorizationKey;
         }
         else {
             this.kbUri = qnaMakerV2ServiceEndpoint + this.options.knowledgeBaseId + '/' + qnaApi;
@@ -42,22 +30,44 @@ var QnAMakerRecognizer = (function () {
         else {
             this.top = this.options.top;
         }
+        this.models = (options.models || {});
     }
     QnAMakerRecognizer.prototype.recognize = function (context, cb) {
         var result = { score: 0.0, answers: null, intent: null };
         if (context && context.message && context.message.text) {
+            var locale = context.locale || '*';
+            var dashPos = locale.indexOf('-');
+            var parentLocale = dashPos > 0 ? locale.substr(0, dashPos) : '*';
+            var model = this.models[locale] || this.models[parentLocale];
             var utterance = context.message.text;
-            QnAMakerRecognizer.recognize(utterance, this.kbUri, this.authorizationKey, this.authHeader, this.top, this.intentName, function (error, result) {
-                if (!error) {
-                    cb(null, result);
-                }
-                else {
-                    cb(error, null);
-                }
-            });
+            if (model) {
+                var authInfo = QnAMakerRecognizer.getAuthValues(model.endpointHostName, model.authorizationKey, model.knowledgeBaseId);
+                QnAMakerRecognizer.recognize(utterance, authInfo.kbUri, authInfo.authorizationKey, authInfo.authHeader, this.top, this.intentName, function (error, result) {
+                    if (!error) {
+                        cb(null, result);
+                    }
+                    else {
+                        cb(error, null);
+                    }
+                });
+            }
+            else if (this.kbUri && this.authorizationKey && this.authHeader) {
+                QnAMakerRecognizer.recognize(utterance, this.kbUri, this.authorizationKey, this.authHeader, this.top, this.intentName, function (error, result) {
+                    if (!error) {
+                        cb(null, result);
+                    }
+                    else {
+                        cb(error, null);
+                    }
+                });
+            }
+            else {
+                cb(null, null);
+            }
         }
     };
     QnAMakerRecognizer.recognize = function (utterance, kbUrl, authkey, authHeader, top, intentName, callback) {
+        var _a;
         try {
             request({
                 url: kbUrl,
@@ -119,7 +129,30 @@ var QnAMakerRecognizer = (function () {
         catch (e) {
             callback(e instanceof Error ? e : new Error(e.toString()));
         }
-        var _a;
+    };
+    QnAMakerRecognizer.getAuthValues = function (endpointHostName, authKey, knowledgeBaseId) {
+        var hostName = endpointHostName.toLowerCase();
+        if (hostName.indexOf('https://') > -1)
+            hostName = hostName.split('/')[2];
+        if (hostName.indexOf("qnamaker") > -1) {
+            hostName = hostName.split('/')[0];
+        }
+        hostName = hostName.replace("/", "");
+        var kbUri = 'https://' + hostName + '/qnamaker/knowledgebases/' + knowledgeBaseId + '/' + qnaApi;
+        var authHeader = 'Authorization';
+        var re = /endpointkey/gi;
+        var authorizationKey = '';
+        if (authKey.search(re) > -1) {
+            authorizationKey = authKey.trim();
+        }
+        else {
+            authorizationKey = 'EndpointKey ' + authKey.trim();
+        }
+        return {
+            authHeader: authHeader,
+            authorizationKey: authorizationKey,
+            kbUri: kbUri
+        };
     };
     return QnAMakerRecognizer;
 }());

--- a/Node/src/botbuilder-cognitiveservices.d.ts
+++ b/Node/src/botbuilder-cognitiveservices.d.ts
@@ -22,6 +22,9 @@ export interface IQnAMakerOptions {
 
     /** The endpoint of the service */
     endpointHostName?: string;
+
+    /** Locale model for different qna makers */
+    models?: IQnAModelMap;
 }
 
 /** Result returned by an QnA Maker recognizer. */
@@ -142,4 +145,20 @@ export class QnAMakerTools{
      * @param qnaMakerResult QnA Maker response from the service. 
      */
     public answerSelector(session: builder.Session, qnaMakerResult: IQnAMakerResults): void;
+}
+
+/**
+ * Model map for qna maker urls to locales
+ */
+export interface IQnAModelMap {
+    [local: string]: ILocaleMap;
+}
+
+/**
+ * Locale map to return authentication values generated from getAuthInfo function
+ */
+export interface ILocaleMap {
+    authorizationKey: string;
+    endpointHostName: string;
+    knowledgeBaseId: string;
 }


### PR DESCRIPTION
Allow support to pass models instead of keys to allow locale support. Follows similar method to LUIS intent recogniser