### PR TITLE
Added GA required endpoint parameter to the QnAMaker samples

### DIFF
--- a/Node/samples/Integral/app.js
+++ b/Node/samples/Integral/app.js
@@ -29,7 +29,7 @@ bot.set('storage', new builder.MemoryBotStorage());         // Register in-memor
 var qnaRecognizer = new cognitiveservices.QnAMakerRecognizer({
     knowledgeBaseId: 'set your kbid here',
     authKey: 'set your authorization key here',
-});
+    endpointHostName: 'set your endpoint host name'});
 
 var LuisModelUrl = '';      // set your LUIS url with LuisActionBinding models (see samples/LuisActionBinding/LUIS_MODEL.json)
 var luisRecognizer = new builder.LuisRecognizer(LuisModelUrl);

--- a/Node/samples/QnAMaker/QnAMakerBotWithActiveLearning/app.js
+++ b/Node/samples/QnAMaker/QnAMakerBotWithActiveLearning/app.js
@@ -28,7 +28,7 @@ server.post('/api/messages', connector.listen());
 var recognizer = new cognitiveservices.QnAMakerRecognizer({
     knowledgeBaseId: 'set your kbid here',
     authKey: 'set your subscription key here',
-    endpointHostName: 'set your endpoint host name'
+    endpointHostName: 'set your endpoint host name',
     top: 3});
 
 var qnaMakerTools = new cognitiveservices.QnAMakerTools();

--- a/Node/samples/QnAMaker/QnAMakerBotWithActiveLearning/app.js
+++ b/Node/samples/QnAMaker/QnAMakerBotWithActiveLearning/app.js
@@ -28,6 +28,7 @@ server.post('/api/messages', connector.listen());
 var recognizer = new cognitiveservices.QnAMakerRecognizer({
     knowledgeBaseId: 'set your kbid here',
     authKey: 'set your subscription key here',
+    endpointHostName: 'set your endpoint host name'
     top: 3});
 
 var qnaMakerTools = new cognitiveservices.QnAMakerTools();

--- a/Node/samples/QnAMaker/QnAMakerSimpleBot/app.js
+++ b/Node/samples/QnAMaker/QnAMakerSimpleBot/app.js
@@ -27,7 +27,8 @@ server.post('/api/messages', connector.listen());
 
 var recognizer = new cognitiveservices.QnAMakerRecognizer({
     knowledgeBaseId: 'set your kbid here',
-    authKey: 'set your authorization key here'});
+    authKey: 'set your authorization key here',
+    endpointHostName: 'set your endpoint host name'});
 
 var basicQnAMakerDialog = new cognitiveservices.QnAMakerDialog({
     recognizers: [recognizer],

--- a/Node/samples/QnAMaker/QnAMakerWithCustomTools/app.js
+++ b/Node/samples/QnAMaker/QnAMakerWithCustomTools/app.js
@@ -29,6 +29,7 @@ server.post('/api/messages', connector.listen());
 var recognizer = new cognitiveservices.QnAMakerRecognizer({
     knowledgeBaseId: 'set your kbid here',
     authKey: 'set your authorization key here',
+    endpointHostName: 'set your endpoint host name',
     top: 4});
 
 var customQnAMakerTools = new customQnAMakerTools.CustomQnAMakerTools();

--- a/Node/samples/QnAMaker/QnAMakerWithFunctionOverrides/app.js
+++ b/Node/samples/QnAMaker/QnAMakerWithFunctionOverrides/app.js
@@ -28,7 +28,7 @@ server.post('/api/messages', connector.listen());
 var recognizer = new cognitiveservices.QnAMakerRecognizer({
     knowledgeBaseId: 'set your kbid here',
     authKey: 'set your authorization key here',
-    endpointHostName: 'set your endpoint host name'
+    endpointHostName: 'set your endpoint host name',
     top: 4});
 
 var qnaMakerTools = new cognitiveservices.QnAMakerTools();

--- a/Node/samples/QnAMaker/QnAMakerWithFunctionOverrides/app.js
+++ b/Node/samples/QnAMaker/QnAMakerWithFunctionOverrides/app.js
@@ -28,6 +28,7 @@ server.post('/api/messages', connector.listen());
 var recognizer = new cognitiveservices.QnAMakerRecognizer({
     knowledgeBaseId: 'set your kbid here',
     authKey: 'set your authorization key here',
+    endpointHostName: 'set your endpoint host name'
     top: 4});
 
 var qnaMakerTools = new cognitiveservices.QnAMakerTools();

--- a/Node/samples/QnAMaker/QnAWithLUIS/app.js
+++ b/Node/samples/QnAMaker/QnAWithLUIS/app.js
@@ -28,6 +28,7 @@ server.post('/api/messages', connector.listen());
 var qnarecognizer = new cognitiveservices.QnAMakerRecognizer({
     knowledgeBaseId: 'set your kbid here',
     authKey: 'set your authorization key here',
+    endpointHostName: 'set your endpoint host name',
     top: 4});
 
 var model='set your luis model uri';


### PR DESCRIPTION
The preview version of QnAMaker will be sustained until 7th November, so new users are using the GA already, therefore they are encountering [problems](https://stackoverflow.com/questions/51164219/trying-to-connect-microsoft-qna-maker-service-with-bot-framework-but-not-getting/) with the current samples because they are not using the GA required endpoint parameter as stated [here](https://blog.botframework.com/2018/05/07/announcing-general-availability-of-qnamaker/)

So, I am adding the parameter to the samples.